### PR TITLE
Typo fix + add launch option method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This guide assumes you have standard Northstar installed already. If you don't, 
 
 2.) Inside of that folder, create another one called `mods`
 
-3.) place the `NP.VanillaPlus` folder inside of that folder
+3.) Place the `NP.VanillaPlus` folder inside of that folder
 
 4.) Download the latest release of Northstar and unzip it
 
@@ -25,13 +25,18 @@ Titanfall2
       +NP.VanillaPlus
 ```
 
-7.) Create a file called `R2Titanfall.txt`, open it and paste the following into it
+7.) There are multiple ways you can launch this profile, the most convenient of which will be gone over
+
+7a.) Add `-northstar -profile=R2Titanfall` as launch options to Titanfall 2 on Steam, then launch Titanfall 2 from Steam
+
+7b.)
+- Create a file called `R2Titanfall.txt` anywhere on your system, open it and paste the following into it, changing `G:\SteamLibrary\steamapps\common\Titanfall2` to be your `Titanfall2 Directory`
 ```
 start "G:\SteamLibrary\steamapps\common\Titanfall2" NorthstarLauncher.exe -norestrictservercommands -profile=R2Titanfall
 ```
-Now save it and rename it to `R2Titanfall.bat`
+- Now save it and rename it to `R2Titanfall.bat`
 
-8.) Double click `R2Titanfall.bat` to launch the Vanilla+ Profile we just made
+- Double click `R2Titanfall.bat` to launch the Vanilla+ Profile we just made
 
 # Install (Easier Alternative Method)
 


### PR DESCRIPTION
Most people looking to play vanilla also like to have their hours counted, which launching using launch options would do. This method also still allows overlays for inviting people and things to work as well, as well as providing generally a better experience when launching (e.g. EA won't open if using a `.bat` file and will freak out. launching via Steam automatically opens EA)

Tested and confirmed working on my machine