### PR TITLE
Have manifest.json use the github url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "NP.VanillaPlus",
     "version_number": "1.3.1",
-    "website_url": "",
+    "website_url": "https://github.com/Zayveeo5e/NP.VanillaPlus",
     "description": "Northstar.Client patch for official servers",
     "dependencies": [
         "northstar-Northstar-1.18.1"


### PR DESCRIPTION
This would make the GitHub url more accessible to users

Instead of going from mod page -> wiki -> GitHub link wiki discussion -> GitHub link on Thunderstore, it would appear on the first page with the mod as shown with [HUD Revamp](https://northstar.thunderstore.io/package/EladNLG/HUDRevamp/) (preview below)

![image](https://github.com/Zayveeo5e/NP.VanillaPlus/assets/70904206/18341813-6db2-4659-a6a2-ed65465e73e1)

If this is merged, it should also have the wiki page deleted Thunderstore side


