### PR TITLE
Updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Patch for Northstar.Client to enable client-side mods on official servers.
 
 # THIS HAS A NON-STANDARD INSTALL PROCESS!
-This guide assumes you have standard Northstar installed already. If you don't, go install that and then come back here.
 
 # Install
 
@@ -27,10 +26,10 @@ Titanfall2
 
 7.) There are multiple ways you can launch this profile, the most convenient of which will be gone over
 
-7a.) Add `-northstar -profile=R2Titanfall` as launch options to Titanfall 2 on Steam, then launch Titanfall 2 from Steam
+7a.) Add `-northstar -norestrictservercommands -profile=R2Titanfall` as launch options to Titanfall 2 on Steam, then launch Titanfall 2 from Steam (recommended, as this will count hours and achievements, where as a `.bat` won't)
 
 7b.)
-- Create a file called `R2Titanfall.txt` anywhere on your system, open it and paste the following into it, changing `G:\SteamLibrary\steamapps\common\Titanfall2` to be your `Titanfall2 Directory`
+- Create a file called `R2Titanfall.txt` in your `Titanfall2` folder, then put the following text in:
 ```
 start NorthstarLauncher.exe -norestrictservercommands -profile=R2Titanfall
 ```


### PR DESCRIPTION
Line 5 was deleted because the guide immediately says to go download Northstar after saying you need to have Northstar already downloaded

7a was changed to add `-norestrictservercommands`, I was able to use it without issue (for some reason), but should be safe rather than sorry. Also clarified that this is recommended as it's more stable and has some of the desired "vanilla" features

7b was changed as the `.bat` file changed to remove the directory mention, but the guide above it didn't reflect the change

i was too lazy to make 3 pr's that would all have merge conflicts :P
also, if when merging you choose `squash and merge`, it will make the commit history cleaner